### PR TITLE
Feature/performance

### DIFF
--- a/src/components/monthlyPerformance.tsx
+++ b/src/components/monthlyPerformance.tsx
@@ -1,0 +1,15 @@
+const MonthlyPerformance = ({monthDate, vaultPosition, venchPercent}: any) => {
+
+    return (
+        <div className="before_nm">
+          <div className="circle_wrap">
+            <div className="vaultCircle" style={{top: vaultPosition + "%"}}></div>
+            <div className="benchCircle" style={{top: venchPercent + "%"}}></div>
+          </div>
+          <span className="bm_txt">{monthDate}</span>
+        </div>
+        
+    )
+}
+
+export default MonthlyPerformance;

--- a/src/components/performance.tsx
+++ b/src/components/performance.tsx
@@ -1,75 +1,88 @@
 const Performance = () => {
-    return (
-        <>
-        <div className="maintitle_wrap">
-          <div className="spacing_100px"></div>
-          <span className="maintitle_txt">Performance</span>
-          <div className="maintitleUnderline"></div>
-        </div>
-        <div className="performance_wrap">
-          <div className="performance">
-            <div className="percentChange_row">
-              <div className="spacing_1px"></div>
-              <span>24%</span>
-              <span>19%</span>
-              <span>14%</span>
-              <span>9%</span>
-              <span>4%</span>
+  return (
+    <>
+      <div className="maintitle_wrap">
+        <div className="spacing_100px"></div>
+        <span className="maintitle_txt">Performance</span>
+        <div className="maintitleUnderline"></div>
+      </div>
+      <div className="performance_wrap">
+        <div className="performance">
+          <div className="percentChange_row">
+            <span>24%</span>
+            <span>19%</span>
+            <span>14%</span>
+            <span>9%</span>
+            <span>4%</span>
+          </div>
+          <div className="performance_monthly">
+            <div className="before_nm">
+              <div className="circle_wrap">
+                <div className="vaultCircle"></div>
+                <div className="benchCircle"></div>
+              </div>
+              <span className="bm_txt">07, 2022</span>
             </div>
-            <div className="performance_monthly">
-              <div className="before_7m before_nm">
+            <div className="before_nm">
+              <div className="circle_wrap">
                 <div className="vaultCircle"></div>
                 <div className="benchCircle"></div>
-                <span className="bm_txt">07, 2022</span>
               </div>
-              <div className="before_6m before_nm">
+              <span className="bm_txt">08, 2022</span>
+            </div>
+            <div className="before_nm">
+              <div className="circle_wrap">
                 <div className="vaultCircle"></div>
                 <div className="benchCircle"></div>
-                <span className="bm_txt">08, 2022</span>
               </div>
-              <div className="before_5m before_nm">
+              <span className="bm_txt">09, 2022</span>
+            </div>
+            <div className="before_nm">
+              <div className="circle_wrap">
                 <div className="vaultCircle"></div>
                 <div className="benchCircle"></div>
-                <span className="bm_txt">09, 2022</span>
               </div>
-              <div className="before_4m before_nm">
+              <span className="bm_txt">10, 2022</span>
+            </div>
+            <div className="before_nm">
+              <div className="circle_wrap">
                 <div className="vaultCircle"></div>
                 <div className="benchCircle"></div>
-                <span className="bm_txt">10, 2022</span>
               </div>
-              <div className="before_3m before_nm">
+              <span className="bm_txt">11, 2022</span>
+            </div>
+            <div className="before_nm">
+              <div className="circle_wrap">
                 <div className="vaultCircle"></div>
                 <div className="benchCircle"></div>
-                <span className="bm_txt">11, 2022</span>
               </div>
-              <div className="before_2m before_nm">
+              <span className="bm_txt">12, 2022</span>
+            </div>
+            <div className="before_nm">
+              <div className="circle_wrap">
                 <div className="vaultCircle"></div>
                 <div className="benchCircle"></div>
-                <span className="bm_txt">12, 2022</span>
               </div>
-              <div className="before_1m before_nm">
-                <div className="vaultCircle"></div>
-                <div className="benchCircle"></div>
-                <span className="bm_txt">01, 2023</span>
-              </div>
+              <span className="bm_txt">01, 2023</span>
             </div>
           </div>
-          <div className="performancesort_wrap">
-            <div className="spacing_64px"></div>
-            <div className="performance_sort">
-              <div className="vault_per_info">
-                <div className="vp_icon"></div>
-                <span className="vp_txt">Static allocation Product</span>
-              </div>
-              <div className="benchmark_per_info">
-                <div className="bm_icon"></div>
-                <span className="bm_txt">Benchmark</span>
-              </div>
+        </div>
+        <div className="performancesort_wrap">
+          <div className="spacing_64px"></div>
+          <div className="performance_sort">
+            <div className="vault_per_info">
+              <div className="vp_icon"></div>
+              <span className="vp_txt">Static allocation Product</span>
+            </div>
+            <div className="benchmark_per_info">
+              <div className="bm_icon"></div>
+              <span className="bm_txt">Benchmark</span>
             </div>
           </div>
         </div>
-        </>
-    );
-}
+      </div>
+    </>
+  );
+};
 
 export default Performance;

--- a/src/components/performance.tsx
+++ b/src/components/performance.tsx
@@ -1,4 +1,12 @@
+import MonthlyPerformance from "./monthlyPerformance";
+import PerformanceHistory from "../utils/PerformanceHistory.json";
+
 const Performance = () => {
+
+  const calcPosition = (historyPercent: number) => {
+    return (historyPercent - PerformanceHistory.percentPoint[0]) * 100 / (PerformanceHistory.percentPoint[4] - PerformanceHistory.percentPoint[0]);
+  }
+
   return (
     <>
       <div className="maintitle_wrap">
@@ -9,62 +17,19 @@ const Performance = () => {
       <div className="performance_wrap">
         <div className="performance">
           <div className="percentChange_row">
-            <span>24%</span>
-            <span>19%</span>
-            <span>14%</span>
-            <span>9%</span>
-            <span>4%</span>
+            {
+              PerformanceHistory.percentPoint.slice(0).reverse().map((cur: number, idx) => {
+                return <span key={idx}>{cur}%</span>
+              })
+            }
           </div>
           <div className="performance_monthly">
-            <div className="before_nm">
-              <div className="circle_wrap">
-                <div className="vaultCircle"></div>
-                <div className="benchCircle"></div>
-              </div>
-              <span className="bm_txt">07, 2022</span>
-            </div>
-            <div className="before_nm">
-              <div className="circle_wrap">
-                <div className="vaultCircle"></div>
-                <div className="benchCircle"></div>
-              </div>
-              <span className="bm_txt">08, 2022</span>
-            </div>
-            <div className="before_nm">
-              <div className="circle_wrap">
-                <div className="vaultCircle"></div>
-                <div className="benchCircle"></div>
-              </div>
-              <span className="bm_txt">09, 2022</span>
-            </div>
-            <div className="before_nm">
-              <div className="circle_wrap">
-                <div className="vaultCircle"></div>
-                <div className="benchCircle"></div>
-              </div>
-              <span className="bm_txt">10, 2022</span>
-            </div>
-            <div className="before_nm">
-              <div className="circle_wrap">
-                <div className="vaultCircle"></div>
-                <div className="benchCircle"></div>
-              </div>
-              <span className="bm_txt">11, 2022</span>
-            </div>
-            <div className="before_nm">
-              <div className="circle_wrap">
-                <div className="vaultCircle"></div>
-                <div className="benchCircle"></div>
-              </div>
-              <span className="bm_txt">12, 2022</span>
-            </div>
-            <div className="before_nm">
-              <div className="circle_wrap">
-                <div className="vaultCircle"></div>
-                <div className="benchCircle"></div>
-              </div>
-              <span className="bm_txt">01, 2023</span>
-            </div>
+            {
+              PerformanceHistory.history.slice(PerformanceHistory.history.length-7,PerformanceHistory.history.length).map((cur, idx) => {
+                return <MonthlyPerformance key={idx} monthDate={cur.date} vaultPosition={calcPosition(cur.vaultPercent)} venchPercent={calcPosition(cur.benchPercent)}/> 
+              })
+            }
+
           </div>
         </div>
         <div className="performancesort_wrap">

--- a/src/pages/vaultdetail.css
+++ b/src/pages/vaultdetail.css
@@ -1284,12 +1284,13 @@
   padding: 0px;
   gap: 27px;
   width: 100%;
-  height: 330px;
+  height: 300px;
   flex: none;
   order: 0;
   flex-grow: 0;
   box-sizing: border-box;
   justify-content: flex-start;
+  margin-top: 30px;
 }
 .performance_wrap .performance {
   display: flex;
@@ -1297,7 +1298,7 @@
   padding: 0px;
   gap: 30px;
   width: 100%;
-  height: 240px;
+  height: 212px;
   flex: none;
   order: 0;
   flex-grow: 0;
@@ -1347,13 +1348,6 @@
   justify-content: flex-start;
   box-sizing: border-box;
 }
-.performance_wrap .performance .percentChange_row .spacing_1px {
-  width: 100%;
-  height: 0.5px;
-  flex: none;
-  order: 0;
-  flex-grow: 0;
-}
 .performance_wrap .performance .percentChange_row span {
   width: auto;
   height: 13px;
@@ -1375,7 +1369,7 @@
 .performance_wrap .performance .performance_monthly {
   display: flex;
   flex-direction: row;
-  align-items: flex-end;
+  align-items: flex-start;
   padding: 0px;
   gap: 57px;
   width: 726px;
@@ -1386,22 +1380,35 @@
   flex-grow: 1;
   justify-content: flex-start;
   box-sizing: border-box;
+  overflow: visible;
 }
 .performance .performance_monthly .before_nm {
   width: 52px;
-  height: 88%;
+  height: 100%;
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+  justify-content: flex-start;
+  box-sizing: border-box;
+  position: relative;
+  transform: rotate(0.5turn);
+}
+.performance .performance_monthly .before_nm .circle_wrap {
+  width: 52px;
+  height: 166px;
   flex: none;
   order: 0;
   flex-grow: 0;
   box-sizing: border-box;
   position: relative;
+  top: 34px;
 }
 .performance_monthly .before_nm .bm_txt {
   position: absolute;
   width: 100%;
   height: 13px;
   flex-grow: 0;
-  bottom: 0;
+  top: 0;
   font-family: "Spoqa Han Sans Neo", sans-serif;
   font-size: 13px;
   font-weight: normal;
@@ -1412,6 +1419,7 @@
   text-align: center;
   align-items: center;
   color: #000;
+  transform: rotate(0.5turn);
 }
 .performance_monthly .before_nm .vaultCircle {
   position: absolute;
@@ -1422,17 +1430,18 @@
   background: #1bc100;
   border-radius: 50%;
   z-index: 10;
+  top: 100%;
 }
 .performance_monthly .before_nm .benchCircle {
   position: absolute;
   width: 13px;
   height: 13px;
-  top: 20px;
   left: 50%;
   transform: translate(-50%, 0);
   background: #dde1e4;
   border-radius: 50%;
   z-index: 8;
+  top: 0;
 }
 .performance_wrap .performancesort_wrap {
   display: flex;

--- a/src/utils/PerformanceHistory.json
+++ b/src/utils/PerformanceHistory.json
@@ -1,0 +1,47 @@
+{
+    "history": [
+        {
+            "date": "07, 2022",
+            "vaultPercent": 14,
+            "benchPercent": 4
+        },
+        {
+            "date": "08, 2022",
+            "vaultPercent": 15,
+            "benchPercent": 4
+        },
+        {
+            "date": "09, 2022",
+            "vaultPercent": 17,
+            "benchPercent": 5
+        },
+        {
+            "date": "10, 2022",
+            "vaultPercent": 19,
+            "benchPercent": 5
+        },
+        {
+            "date": "11, 2022",
+            "vaultPercent": 21,
+            "benchPercent": 6
+        },
+        {
+            "date": "12, 2022",
+            "vaultPercent": 23,
+            "benchPercent": 6
+        },
+        {
+            "date": "01, 2022",
+            "vaultPercent": 24,
+            "benchPercent": 7
+        },
+        {
+            "date": "02, 2022",
+            "vaultPercent": 24,
+            "benchPercent": 10
+        }
+    ],
+    "percentPoint": [
+        4, 9, 14, 19, 24
+    ]
+}


### PR DESCRIPTION
## Summary
performance 부분 json을 활용하도록 변경

## 상세 설명
* src/utils/PerformanceHistory.json
    Performance에 찍힐 정보들을 저장하는 json
    * history : 날짜, 초록색 점(product), 회색 점(bench) 
                     → 7개만 화면에 보이며, json에 7개 넘는 항목이 있어도 자동으로 7개만 화면에 보여줌
    * percentPoint : y축에 찍히는 범주 5개
                               → 5개만 화면에 보이며, json 파일에도 5개만 보여주어야 함
    * 1주일에 한 번씩 history를 추가하면 됨 (가장 왼쪽에 추가됨)
* src/components/monthlyPerformance.tsx
    * history 1개에 해당하는 코드를 따로 component로 정리
* src/components/performance.tsx
    * json에 저장된 %값에 맞춰서 해당되는 위치에 찍어줄 수 있도록 계산하는 로직 추가
    * ex. y축에 나타나는 범주가 10, 15, 20, 25, 30% 일때, product의 performance가 20%임 
             이런 경우에는 y축의 20%에 맞춰서 점을 찍어야 함(실제 위치는 50%위치) 이를 위해 20%를 50%로 바꾸는 작업이 필요


